### PR TITLE
Add type conversions to fix compiler warnings

### DIFF
--- a/src/weighted_mean.c
+++ b/src/weighted_mean.c
@@ -84,8 +84,8 @@ _weighted_mean_intermediate(PG_FUNCTION_ARGS)
 		oldcontext = MemoryContextSwitchTo(internalcontext);
 		state = (WeightedMeanInternalState *) palloc(sizeof(WeightedMeanInternalState));
 		state->mcontext = internalcontext;
-		state->running_sum = make_zero();
-		state->running_amount = make_zero();
+		state->running_sum = DatumGetNumeric(make_zero());
+		state->running_amount = DatumGetNumeric(make_zero());
 	}
 	else
 	{


### PR DESCRIPTION
The fix for issue #1 introduced new compiler warnings:

```
src/weighted_mean.c: In function ‘_weighted_mean_intermediate’:
src/weighted_mean.c:87:22: warning: assignment makes pointer from integer without a cast [enabled by default]
src/weighted_mean.c:88:25: warning: assignment makes pointer from integer without a cast [enabled by default]
```

This patch fixes those.
